### PR TITLE
vulkan: link SPIRV-Headers after find_package(SPIRV-Headers CONFIG REQUIRED)

### DIFF
--- a/src/ggml-vulkan/CMakeLists.txt
+++ b/src/ggml-vulkan/CMakeLists.txt
@@ -109,7 +109,7 @@ if (Vulkan_FOUND)
         "GGML_VULKAN_FLOAT_E4M3_GLSLC_SUPPORT"
     )
 
-    target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
+    target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan SPIRV-Headers::SPIRV-Headers)
     target_include_directories(ggml-vulkan PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
     # Workaround to the "can't dereference invalidated vector iterator" bug in clang-cl debug build


### PR DESCRIPTION
CMake dependency hygiene: `find_package(SPIRV-Headers CONFIG REQUIRED)` is required, but the imported target is never linked to `ggml-vulkan`, so the SPIRV-Headers include directory is not propagated to consumers and `<spirv/unified1/spirv.hpp>` fails to resolve during an Android NDK cross-build. Linking the imported target lets the CONFIG package's include dirs reach the compiler.

This change is CMake dependency hygiene; it does not claim Android inference/runtime validation.